### PR TITLE
DSO-632: added tag policy

### DIFF
--- a/.github/sp/add-policy-contributor.sh
+++ b/.github/sp/add-policy-contributor.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+az role assignment create --role "Resource Policy Contributor" --assignee 'http://dso-infra-azure-tags' --scope '/providers/Microsoft.Management/managementGroups/747381f4-e81f-4a43-bf68-ced6a1e14edf'

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -51,10 +51,10 @@ jobs:
             # any other push - deploy with check flag set
             checkflag="true"
           fi
-          if [[ checkflag = "true" ]]; then
-            echo "::set-output name=policyaction::show"
+          if [[ checkflag == "false" ]]; then
+            echo "::set-output name=policyaction::create"
           else
-            echo "::set-output name=policyaction::update"
+            echo "::set-output name=policyaction::show"
           fi
 
       - name: Azure Login

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -1,0 +1,87 @@
+name: policy
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - policy/**
+  pull_request:
+    branches:
+      - main
+    paths:
+      - policy/**
+  workflow_dispatch:
+    inputs:
+      checkflag:
+        description: 'If true, validate the changes. If false, apply the changes'
+        required: true
+        default: 'true'
+
+jobs:
+  # This workflow can be triggered multiple ways,
+  # e.g. manually or by push/pull request.
+  # The first job figures out the parameters based on trigger type.
+  # The second job runs ansible for each environment
+  prepare-tags:
+    runs-on:
+      - ubuntu-latest
+    outputs:
+      apply_tags: ${{ steps.parseinput.outputs.apply_tags }}
+      aztagscli_args: ${{ steps.setupargs.outputs.aztagscli_args }}
+      env_matrix: ${{ steps.setupenv.outputs.env_matrix }}
+    steps:
+      - name: Clone repo
+        uses: actions/checkout@v2
+
+      - name: Parse inputs
+        id: parseinput
+        run: |
+          echo "Parsing input parameters event=${GITHUB_EVENT_NAME}"
+          branch=$(echo ${GITHUB_REF##*/})
+          echo "Extracted last part of branch [${branch}] from ${GITHUB_REF}"
+          # figure out which environment to deploy to and whether to set checkflag or not
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            # manual trigger - take params from inputs
+            checkflag="${{ github.event.inputs.checkflag }}"
+          elif [[ "${GITHUB_EVENT_NAME}" == "push" && ( "${branch}" == "master" || "${branch}" == "main" ) ]]; then
+            # push to master/main - deploy for real
+            checkflag="false"
+          else
+            # any other push - deploy with check flag set
+            checkflag="true"
+          fi
+          if [[ checkflag = "true" ]]; then
+            echo "::set-output name=policyaction::show"
+          else
+            echo "::set-output name=policyaction::update"
+          fi
+
+      - name: Azure Login
+        uses: azure/login@v1.1
+        with:
+          creds: ${{secrets.AZURE_CREDENTIALS}}
+
+      - name: Process policy definition
+        env:
+          policyaction: ${{ steps.parseinput.outputs.policyaction }}
+        run: |
+          cd policy/definition
+          echo ./az-policy-definition.sh ${{ policyaction }}
+          ./az-policy-definition.sh ${{ policyaction }}
+
+      - name: Process policy initiative
+        env:
+          policyaction: ${{ steps.parseinput.outputs.policyaction }}
+        run: |
+          cd policy/set-definition
+          echo ./az-policy-set-definition.sh ${{ policyaction }}
+          ./az-policy-set-definition.sh ${{ policyaction }}
+
+      - name: Process policy assignment
+        env:
+          policyaction: ${{ steps.parseinput.outputs.policyaction }}
+        run: |
+          cd policy/assignment
+          echo ./az-policy-assignment.sh ${{ policyaction }}
+          ./az-policy-assignment.sh ${{ policyaction }}

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -23,7 +23,7 @@ jobs:
   # e.g. manually or by push/pull request.
   # The first job figures out the parameters based on trigger type.
   # The second job runs ansible for each environment
-  prepare-tags:
+  process-policies:
     runs-on:
       - ubuntu-latest
     outputs:

--- a/.github/workflows/policy.yml
+++ b/.github/workflows/policy.yml
@@ -67,21 +67,21 @@ jobs:
           policyaction: ${{ steps.parseinput.outputs.policyaction }}
         run: |
           cd policy/definition
-          echo ./az-policy-definition.sh ${{ policyaction }}
-          ./az-policy-definition.sh ${{ policyaction }}
+          echo ./az-policy-definition.sh ${policyaction}
+          ./az-policy-definition.sh ${policyaction}
 
       - name: Process policy initiative
         env:
           policyaction: ${{ steps.parseinput.outputs.policyaction }}
         run: |
           cd policy/set-definition
-          echo ./az-policy-set-definition.sh ${{ policyaction }}
-          ./az-policy-set-definition.sh ${{ policyaction }}
+          echo ./az-policy-set-definition.sh ${policyaction}
+          ./az-policy-set-definition.sh ${policyaction}
 
       - name: Process policy assignment
         env:
           policyaction: ${{ steps.parseinput.outputs.policyaction }}
         run: |
           cd policy/assignment
-          echo ./az-policy-assignment.sh ${{ policyaction }}
-          ./az-policy-assignment.sh ${{ policyaction }}
+          echo ./az-policy-assignment.sh ${policyaction}
+          ./az-policy-assignment.sh ${policyaction}

--- a/policy/README.md
+++ b/policy/README.md
@@ -1,0 +1,62 @@
+# Setup of Azure DSO tag policy via AZ CLI
+
+Consists of a generic `RequireTagAndRestrictValueOnResources` policy definition
+to ensure a tag is defined, and the tag's value is one of a given set of values.
+An initiative (or set-definition) that enforces `service`, `application` and 
+`environment_name` tags on resources, and ensures the values match a 
+pre-determined list.  And assignments for each of the DSO subscriptions that
+uses these tags.
+
+## Definition
+
+A generic `Require a tag and restrict value on resources` policy definition to
+ensure a tag is defined, and the tag's value is one of a given set of values.
+The `az-policy-definition.sh` helper script wraps the az cli.  Example usage:
+
+```
+# ensure AZ logged in
+cd definition
+
+# show existing definitions
+./az-policy-definition.sh show
+
+# update existing definitions
+./az-policy-definition.sh update
+```
+
+## Initiative 
+
+A `DSO resource tag Initiative` initiative (or set-definition) that enforces 
+`service`, `application` and `environment_name` tags on resources, and ensures 
+the values match a pre-determined list.  The `az-policy-set-definition.sh` 
+helper script wraps the az cli.  Example usage:
+
+
+```
+# ensure AZ logged in
+cd set-definition
+
+# show existing set-definitions
+./az-policy-set-definition.sh show
+
+# update existing set-definitions
+./az-policy-set-definition.sh update
+```
+
+## Assignment
+
+Assign the initiative to all relevant subscriptions.  The supported tag values
+are defined in assignment/azurepolicyassignment.parameters.json.  The
+`az-policy-assignment.sh` helper script wraps the az cli.  Example usage:
+
+```
+# ensure AZ logged in
+cd assignment
+
+# show existing set-definitions
+./az-policy-assignment.sh show
+
+# update existing set-definitions
+./az-policy-assignment.sh update
+```
+

--- a/policy/assignment/DigitalStudioDevTestEnvironments/azurepolicyassignment.settings
+++ b/policy/assignment/DigitalStudioDevTestEnvironments/azurepolicyassignment.settings
@@ -1,0 +1,5 @@
+policy_set_name="/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policySetDefinitions/DSOTagsInitiative"
+policy_assignment_name="DigitalStudioDevTestEnvironmentsDSOTagsInitiative"
+policy_assignment_display_name="Digital Studio Dev & Test Environments DSO Tags Initiative"
+policy_assignment_enforcement_mode="DoNotEnforce"
+policy_assignment_scope="/subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7"

--- a/policy/assignment/NOMSDevTestEnvironments/azurepolicyassignment.settings
+++ b/policy/assignment/NOMSDevTestEnvironments/azurepolicyassignment.settings
@@ -1,0 +1,5 @@
+policy_set_name="/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policySetDefinitions/DSOTagsInitiative"
+policy_assignment_name="NOMSDevTestEnvironmentsDSOTagsInitiative"
+policy_assignment_display_name="NOMS Dev & Test Environments DSO Tags Initiative"
+policy_assignment_enforcement_mode="DoNotEnforce"
+policy_assignment_scope="/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb"

--- a/policy/assignment/NOMSDigitalStudioProduction1/azurepolicyassignment.settings
+++ b/policy/assignment/NOMSDigitalStudioProduction1/azurepolicyassignment.settings
@@ -1,0 +1,5 @@
+policy_set_name="/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policySetDefinitions/DSOTagsInitiative"
+policy_assignment_name="NOMSDigitalStudioProduction1DSOTagsInitiative"
+policy_assignment_display_name="NOMS Digital Studio Production 1 DSO Tags Initiative"
+policy_assignment_enforcement_mode="DoNotEnforce"
+policy_assignment_scope="/subscriptions/a5ddf257-3b21-4ba9-a28c-ab30f751b383"

--- a/policy/assignment/NOMSProduction1/azurepolicyassignment.settings
+++ b/policy/assignment/NOMSProduction1/azurepolicyassignment.settings
@@ -1,0 +1,5 @@
+policy_set_name="/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policySetDefinitions/DSOTagsInitiative"
+policy_assignment_name="NOMSProduction1DSOTagsInitiative"
+policy_assignment_display_name="NOMS Production 1 DSO Tags Initiative"
+policy_assignment_enforcement_mode="DoNotEnforce"
+policy_assignment_scope="/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b"

--- a/policy/assignment/P-NOMISDSOdevelopment/azurepolicyassignment.settings
+++ b/policy/assignment/P-NOMISDSOdevelopment/azurepolicyassignment.settings
@@ -1,0 +1,5 @@
+policy_set_name="/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policySetDefinitions/DSOTagsInitiative"
+policy_assignment_name="PNOMISDSOdevelopmentDSOTagsInitiative"
+policy_assignment_display_name="P-NOMIS DSO development DSO Tags Initiative"
+policy_assignment_enforcement_mode="DoNotEnforce"
+policy_assignment_scope="/subscriptions/22b0ff4c-6d78-4964-ac2a-b7cda4a58755"

--- a/policy/assignment/P-NOMISnonproduction/azurepolicyassignment.settings
+++ b/policy/assignment/P-NOMISnonproduction/azurepolicyassignment.settings
@@ -1,0 +1,5 @@
+policy_set_name="/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policySetDefinitions/DSOTagsInitiative"
+policy_assignment_name="PNOMISnonproductionDSOTagsInitiative"
+policy_assignment_display_name="P-NOMIS non-production DSO Tags Initiative"
+policy_assignment_enforcement_mode="DoNotEnforce"
+policy_assignment_scope="/subscriptions/b9aa011b-7a41-46e1-8088-4a32e4bd92e0"

--- a/policy/assignment/P-NOMISproduction/azurepolicyassignment.settings
+++ b/policy/assignment/P-NOMISproduction/azurepolicyassignment.settings
@@ -1,0 +1,5 @@
+policy_set_name="/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policySetDefinitions/DSOTagsInitiative"
+policy_assignment_name="PNOMISproductionDSOTagsInitiative"
+policy_assignment_display_name="P-NOMIS production DSO Tags Initiative"
+policy_assignment_enforcement_mode="DoNotEnforce"
+policy_assignment_scope="/subscriptions/4bdc3aa7-2dbe-4031-aaa1-20456ed7b221"

--- a/policy/assignment/az-policy-assignment.sh
+++ b/policy/assignment/az-policy-assignment.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+  echo "Usage: $0 create|update|delete|show [<dir1> .. <dirN>]"
+  echo 
+  echo "Manage policy assignments contained within given sub-directories, or all sub-directories if none specified"
+}
+
+get_setting() {
+  local setting=$(grep "^$1=\"" $2 | cut -d\" -f2)
+  if [[ -z $setting ]]; then
+    setting=$(grep "^$1='" $2 | cut -d\' -f2)
+  fi
+  if [[ -z $setting ]]; then
+    setting=$(grep "^$1=" $2 | cut -d= -f2)
+  fi
+  if [[ -z $setting ]]; then
+    echo "Setting [$1] not found in $2" >&2
+  fi
+  echo $setting
+}
+
+apply_policy_set_definition_assignment() {
+  local action=$1
+  local policy=$2
+  if [[ ! -e $policy ]]; then
+    echo "Directory [$policy] doesn't exist"
+    exit 1
+  fi
+  local policy_assignment_name=$(get_setting "policy_assignment_name" $dir/azurepolicyassignment.settings)
+  local policy_assignment_display_name=$(get_setting "policy_assignment_display_name" $dir/azurepolicyassignment.settings)
+  local policy_assignment_enforcement_mode=$(get_setting "policy_assignment_enforcement_mode" $dir/azurepolicyassignment.settings)
+  local policy_assignment_scope=$(get_setting "policy_assignment_scope" $dir/azurepolicyassignment.settings)
+  local policy_set_name=$(get_setting "policy_set_name" $dir/azurepolicyassignment.settings)
+
+  if [[ -z $policy_assignment_name || -z $policy_assignment_display_name || -z $policy_assignment_enforcement_mode || -z $policy_assignment_scope || -z $policy_set_name ]]; then
+    exit 1
+  fi
+
+  if [[ $action == "create" ]]; then
+    echo az policy assignment create --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
+    az policy assignment create --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
+  elif [[ $action == "update" ]]; then
+    echo az policy assignment update --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
+    az policy assignment update --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
+  elif [[ $action == "delete" ]]; then
+    echo az policy assignment delete --name "$policy_assignment_name" --scope "$policy_assignment_scope"
+    az policy assignment delete --name "$policy_assignment_name" --scope "$policy_assignment_scope"
+  elif [[ $action == "show" ]]; then
+    echo az policy assignment show --name "$policy_assignment_name" --scope "$policy_assignment_scope"
+    az policy assignment show --name "$policy_assignment_name" --scope "$policy_assignment_scope"
+  else
+    echo "Unknown action [$action].  Expected create|update|delete|show"
+  fi
+
+}
+
+action=$1
+if [[ -z $action ]]; then
+  usage
+  exit 1
+fi
+shift
+
+dirs=$@
+if [[ -z $dirs ]]; then
+  dirs=$(ls -1d -- */ | sed 's/\/$//')
+fi
+
+for dir in $dirs; do
+  apply_policy_set_definition_assignment "$action" "$dir"
+done

--- a/policy/assignment/az-policy-assignment.sh
+++ b/policy/assignment/az-policy-assignment.sh
@@ -3,7 +3,7 @@
 set -e
 
 usage() {
-  echo "Usage: $0 create|update|delete|show [<dir1> .. <dirN>]"
+  echo "Usage: $0 create|delete|show [<dir1> .. <dirN>]"
   echo 
   echo "Manage policy assignments contained within given sub-directories, or all sub-directories if none specified"
 }
@@ -42,9 +42,6 @@ apply_policy_set_definition_assignment() {
   if [[ $action == "create" ]]; then
     echo az policy assignment create --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
     az policy assignment create --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
-  elif [[ $action == "update" ]]; then
-    echo az policy assignment update --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
-    az policy assignment update --name "$policy_assignment_name" --display-name "$policy_assignment_display_name" --enforcement-mode "$policy_assignment_enforcement_mode" --params azurepolicyassignment.parameters.json --policy-set-definition "$policy_set_name" --scope "$policy_assignment_scope"
   elif [[ $action == "delete" ]]; then
     echo az policy assignment delete --name "$policy_assignment_name" --scope "$policy_assignment_scope"
     az policy assignment delete --name "$policy_assignment_name" --scope "$policy_assignment_scope"

--- a/policy/assignment/azurepolicyassignment.parameters.json
+++ b/policy/assignment/azurepolicyassignment.parameters.json
@@ -1,0 +1,51 @@
+{
+  "serviceTagValues": {
+    "value": [
+      "CAFM",
+      "CSR",
+      "FixNGo",
+      "Misc",
+      "NOMIS",
+      "NonCore",
+      "OASys",
+      "Unknown"
+    ]
+  },
+  "applicationTagValues": {
+    "value": [
+      "BookASecureMove",
+      "CAFM",
+      "CAFMAssetMgmt",
+      "CAFMInternal",
+      "CAFMPlanetFM",
+      "CAFMTraining",
+      "CSR",
+      "HMPPSInformationReport",
+      "MIS",
+      "Management",
+      "NDH",
+      "NOMIS",
+      "Network",
+      "NonCore",
+      "OASys",
+      "ONR",
+      "OR",
+      "Transit",
+      "Uncategorised",
+      "Unknown"
+    ]
+  },
+  "environmentNameTagValues": {
+    "value": [
+      "DR",
+      "T1",
+      "T2",
+      "T3",
+      "devtest",
+      "lsast",
+      "preprod",
+      "prod",
+      "syscon"
+    ]
+  }
+}

--- a/policy/assignment/azurepolicyassignment.parameters.json
+++ b/policy/assignment/azurepolicyassignment.parameters.json
@@ -45,7 +45,8 @@
       "lsast",
       "preprod",
       "prod",
-      "syscon"
+      "syscon",
+      "poc"
     ]
   }
 }

--- a/policy/definition/RequireTagAndRestrictValueOnResources/azurepolicy.parameters.json
+++ b/policy/definition/RequireTagAndRestrictValueOnResources/azurepolicy.parameters.json
@@ -1,0 +1,17 @@
+{
+  "tagName": {
+    "type": "String",
+    "metadata": {
+      "displayName": "Tag Name",
+      "description": "Name of the tag, such as 'environment'"
+    }
+  },
+  "tagValues": {
+    "type": "array",
+    "metadata": {
+      "displayName": "List of allowed tag values",
+      "description": "The list of allowed values for the given tag"
+    },
+    "defaultValue": []
+  }
+}

--- a/policy/definition/RequireTagAndRestrictValueOnResources/azurepolicy.rules.json
+++ b/policy/definition/RequireTagAndRestrictValueOnResources/azurepolicy.rules.json
@@ -1,0 +1,11 @@
+{
+  "if": {
+    "not": {
+      "field": "[concat('tags[', parameters('tagName'), ']')]",
+      "in": "[parameters('tagValues')]"
+    }
+  },
+  "then": {
+    "effect": "deny"
+  }
+}

--- a/policy/definition/RequireTagAndRestrictValueOnResources/azurepolicy.settings
+++ b/policy/definition/RequireTagAndRestrictValueOnResources/azurepolicy.settings
@@ -1,0 +1,6 @@
+# create definition in "Tenant Root Group" management group so accessible by all subs
+policy_name="RequireTagAndRestrictValueOnResources"
+policy_display_name="Require a tag and restrict value on resources"
+policy_description="Enforce a required tag and check its value matches any one of a given set of values.  Does not apply to resource groups"
+policy_management_group="747381f4-e81f-4a43-bf68-ced6a1e14edf"
+policy_metadata="category=Tags"

--- a/policy/definition/az-policy-definition.sh
+++ b/policy/definition/az-policy-definition.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+  echo "Usage: $0 create|update|delete|show [<dir1> .. <dirN>]"
+  echo 
+  echo "Manage policy definitions contained within given sub-directories, or all sub-directories if none specified"
+}
+
+get_setting() {
+  local setting=$(grep "^$1=\"" $2 | cut -d\" -f2)
+  if [[ -z $setting ]]; then
+    setting=$(grep "^$1='" $2 | cut -d\' -f2)
+  fi
+  if [[ -z $setting ]]; then
+    setting=$(grep "^$1=" $2 | cut -d= -f2)
+  fi
+  if [[ -z $setting ]]; then
+    echo "Setting [$1] not found in $2" >&2
+  fi
+  echo $setting
+}
+
+apply_policy_definition() {
+  local action=$1
+  local policy=$2
+  if [[ ! -e $policy ]]; then
+    echo "Directory [$policy] doesn't exist"
+    exit 1
+  fi
+  local policy_name=$(get_setting "policy_name" $dir/azurepolicy.settings)
+  local policy_display_name=$(get_setting "policy_display_name" $dir/azurepolicy.settings)
+  local policy_description=$(get_setting "policy_description" $dir/azurepolicy.settings)
+  local policy_management_group=$(get_setting "policy_management_group" $dir/azurepolicy.settings)
+  local policy_metadata=$(get_setting "policy_metadata" $dir/azurepolicy.settings)
+  if [[ -z $policy_name || -z $policy_display_name || -z $policy_description || -z $policy_management_group || -z $policy_metadata ]]; then
+    exit 1
+  fi
+
+  if [[ $action == "create" ]]; then
+    echo az policy definition create --name "$policy_name" --display-name "$policy_display_name" --description "$policy_description" --rules "$policy/azurepolicy.rules.json" --params "$policy/azurepolicy.parameters.json" --mode indexed --management-group "$policy_management_group" --metadata "$policy_metadata"
+    az policy definition create --name "$policy_name" --display-name "$policy_display_name" --description "$policy_description" --rules "$policy/azurepolicy.rules.json" --params "$policy/azurepolicy.parameters.json" --mode indexed --management-group "$policy_management_group" --metadata "$policy_metadata"
+  elif [[ $action == "update" ]]; then
+    echo az policy definition update --name "$policy_name" --display-name "$policy_display_name" --description "$policy_description" --rules "$policy/azurepolicy.rules.json" --params "$policy/azurepolicy.parameters.json" --mode indexed --management-group "$policy_management_group" --metadata "$policy_metadata"
+    az policy definition update --name "$policy_name" --display-name "$policy_display_name" --description "$policy_description" --rules "$policy/azurepolicy.rules.json" --params "$policy/azurepolicy.parameters.json" --mode indexed --management-group "$policy_management_group" --metadata "$policy_metadata"
+  elif [[ $action == "delete" ]]; then
+    echo az policy definition delete --name "$policy_name" --management-group "$policy_management_group"
+    az policy definition delete --name "$policy_name" --management-group "$policy_management_group"
+  elif [[ $action == "show" ]]; then
+    echo az policy definition show --name "$policy_name" --management-group "$policy_management_group"
+    az policy definition show --name "$policy_name" --management-group "$policy_management_group"
+  else
+    echo "Unknown action [$action].  Expected create|update|delete|show"
+  fi
+  
+}
+
+action=$1
+if [[ -z $action ]]; then
+  usage
+  exit 1
+fi
+shift
+
+dirs=$@
+if [[ -z $dirs ]]; then
+  dirs=$(ls -1d -- */ | sed 's/\/$//')
+fi
+
+for dir in $dirs; do
+  apply_policy_definition "$action" "$dir"
+done

--- a/policy/set-definition/DSOTagsInitiative/azurepolicyset.definitions.json
+++ b/policy/set-definition/DSOTagsInitiative/azurepolicyset.definitions.json
@@ -1,0 +1,35 @@
+[
+  {
+    "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policyDefinitions/RequireTagAndRestrictValueOnResources",
+    "parameters": {
+      "tagName": {
+        "value": "service"
+      },
+      "tagValues": {
+        "value": "[parameters('serviceTagValues')]"
+      }
+    }
+  },
+  {
+    "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policyDefinitions/RequireTagAndRestrictValueOnResources",
+    "parameters": {
+      "tagName": {
+        "value": "application"
+      },
+      "tagValues": {
+        "value": "[parameters('applicationTagValues')]"
+      }
+    }
+  },
+  {
+    "policyDefinitionId": "/providers/Microsoft.Management/managementgroups/747381f4-e81f-4a43-bf68-ced6a1e14edf/providers/Microsoft.Authorization/policyDefinitions/RequireTagAndRestrictValueOnResources",
+    "parameters": {
+      "tagName": {
+        "value": "environment_name"
+      },
+      "tagValues": {
+        "value": "[parameters('environmentNameTagValues')]"
+      }
+    }
+  }
+]

--- a/policy/set-definition/DSOTagsInitiative/azurepolicyset.parameters.json
+++ b/policy/set-definition/DSOTagsInitiative/azurepolicyset.parameters.json
@@ -1,0 +1,36 @@
+{
+  "serviceTagValues": {
+    "type": "array",
+    "metadata": {
+      "displayName": "The list of allowed values for the 'service' tag",
+      "description": "Allowed values for the 'service' tag, such as 'NOMIS'"
+    },
+    "defaultValue": [
+      "NOMIS",
+      "OASys"
+    ]
+  },
+  "applicationTagValues": {
+    "type": "array",
+    "metadata": {
+      "displayName": "The list of allowed values for the 'application' tag",
+      "description": "Allowed values for the 'application' tag, such as 'NOMIS'"
+    },
+    "defaultValue": [
+      "NOMIS",
+      "OASys"
+    ]
+  },
+  "environmentNameTagValues": {
+    "type": "array",
+    "metadata": {
+      "displayName": "The list of allowed values for the 'environment_name' tag",
+      "description": "Allowed values for the 'environment_name' tag, such as 'prod'"
+    },
+    "defaultValue": [
+      "prod",
+      "devtest",
+      "T1"
+    ]
+  }
+}

--- a/policy/set-definition/DSOTagsInitiative/azurepolicyset.settings
+++ b/policy/set-definition/DSOTagsInitiative/azurepolicyset.settings
@@ -1,0 +1,6 @@
+# create definition in "Tenant Root Group" management group so accessible by all subs
+policy_set_name="DSOTagsInitiative"
+policy_set_display_name="DSO resource tag Initiative"
+policy_set_description="Ensure a set of tags are defined on resources to allow effective management of HMPPS azure estate"
+policy_set_management_group="747381f4-e81f-4a43-bf68-ced6a1e14edf"
+policy_set_metadata="category=Tags"

--- a/policy/set-definition/az-policy-set-definition.sh
+++ b/policy/set-definition/az-policy-set-definition.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+usage() {
+  echo "Usage: $0 create|update|delete|show [<dir1> .. <dirN>]"
+  echo 
+  echo "Manage policy set definitions contained within given sub-directories, or all sub-directories if none specified"
+}
+
+get_setting() {
+  local setting=$(grep "^$1=\"" $2 | cut -d\" -f2)
+  if [[ -z $setting ]]; then
+    setting=$(grep "^$1='" $2 | cut -d\' -f2)
+  fi
+  if [[ -z $setting ]]; then
+    setting=$(grep "^$1=" $2 | cut -d= -f2)
+  fi
+  if [[ -z $setting ]]; then
+    echo "Setting [$1] not found in $2" >&2
+  fi
+  echo $setting
+}
+
+apply_policy_set_definition() {
+  local action=$1
+  local policy=$2
+  if [[ ! -e $policy ]]; then
+    echo "Directory [$policy] doesn't exist"
+    exit 1
+  fi
+  local policy_set_name=$(get_setting "policy_set_name" $dir/azurepolicyset.settings)
+  local policy_set_display_name=$(get_setting "policy_set_display_name" $dir/azurepolicyset.settings)
+  local policy_set_description=$(get_setting "policy_set_description" $dir/azurepolicyset.settings)
+  local policy_set_management_group=$(get_setting "policy_set_management_group" $dir/azurepolicyset.settings)
+  local policy_set_metadata=$(get_setting "policy_set_metadata" $dir/azurepolicyset.settings)
+  if [[ -z $policy_set_name || -z $policy_set_display_name || -z $policy_set_description || -z $policy_set_management_group || -z $policy_set_metadata ]]; then
+    exit 1
+  fi
+
+  if [[ $action == "create" ]]; then
+    echo az policy set-definition create --name "$policy_set_name" --display-name "$policy_set_display_name" --description "$policy_set_description" --definitions "$policy/azurepolicyset.definitions.json" --params "$policy/azurepolicyset.parameters.json" --management-group "$policy_set_management_group" --metadata "$policy_set_metadata"
+    az policy set-definition create --name "$policy_set_name" --display-name "$policy_set_display_name" --description "$policy_set_description" --definitions "$policy/azurepolicyset.definitions.json" --params "$policy/azurepolicyset.parameters.json" --management-group "$policy_set_management_group" --metadata "$policy_set_metadata"
+  elif [[ $action == "update" ]]; then
+    echo az policy set-definition update --name "$policy_set_name" --display-name "$policy_set_display_name" --description "$policy_set_description" --definitions "$policy/azurepolicyset.definitions.json" --params "$policy/azurepolicyset.parameters.json" --management-group "$policy_set_management_group" --metadata "$policy_set_metadata"
+    az policy set-definition update --name "$policy_set_name" --display-name "$policy_set_display_name" --description "$policy_set_description" --definitions "$policy/azurepolicyset.definitions.json" --params "$policy/azurepolicyset.parameters.json" --management-group "$policy_set_management_group" --metadata "$policy_set_metadata"
+  elif [[ $action == "delete" ]]; then
+    echo az policy set-definition delete --name "$policy_set_name" --management-group "$policy_set_management_group"
+    az policy set-definition delete --name "$policy_set_name" --management-group "$policy_set_management_group"
+  elif [[ $action == "show" ]]; then
+    echo az policy set-definition show --name "$policy_set_name" --management-group "$policy_set_management_group"
+    az policy set-definition show --name "$policy_set_name" --management-group "$policy_set_management_group"
+  else
+    echo "Unknown action [$action].  Expected create|update|delete"
+  fi
+  
+}
+
+action=$1
+if [[ -z $action ]]; then
+  usage
+  exit 1
+fi
+shift
+
+dirs=$@
+if [[ -z $dirs ]]; then
+  dirs=$(ls -1d -- */ | sed 's/\/$//')
+fi
+
+for dir in $dirs; do
+  apply_policy_set_definition "$action" "$dir"
+done
+


### PR DESCRIPTION
Add policy to ensure service, application and environment_name tags are defined in each of our relevant subscriptions.