### PR TITLE
align tags with DSO sheet, mainly nomis DB tagging updates

### DIFF
--- a/tags/DigitalStudioDevTestEnvironments/service_app_env_desc/inherit.AzureDSO.rgstags.txt
+++ b/tags/DigitalStudioDevTestEnvironments/service_app_env_desc/inherit.AzureDSO.rgstags.txt
@@ -14,8 +14,3 @@ id|tags.service|tags.application|tags.component|tags.environment_name
 /subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/rg-fortigate-backups-devtest|FixNGo|Transit||devtest
 /subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/test-nomis|NOMISAPI|NOMISAPI||devtest
 /subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/webops-shared-dns-devtest|FixNGo|Management||devtest
-/subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/wmt-integration|WMT|WMT||devtest
-/subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/wmt-mgmt-nonprod|WMT|WMT||devtest
-/subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/wmt-networking-nonprod|WMT|WMT||devtest
-/subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/wmt-staging|WMT|WMT||devtest
-/subscriptions/c27cfedb-f5e9-45e6-9642-0fad1a5c94e7/resourceGroups/wmt-test|WMT|WMT||devtest

--- a/tags/NOMSDevTestEnvironments/service_app_component_env_desc/inherit.AzureDSO.resourcestags.txt
+++ b/tags/NOMSDevTestEnvironments/service_app_component_env_desc/inherit.AzureDSO.resourcestags.txt
@@ -39,14 +39,14 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/hmpps-devtest-ukwest-appgw-rg/providers/Microsoft.Network/applicationGateways/hmpps-devtest-ukwest-appgw2|FixNGo|Transit||devtest|
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/hmpps-devtest-ukwest-appgw-rg/providers/Microsoft.Network/applicationGateways/hmpps-devtest-ukwest-appgw3|FixNGo|Transit||devtest|
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_ukwest/flowLogs/Microsoft.Networkhmpps-devtest-ukwest-appgw-rghmpps-devtest-ukwest-appgw2-nsg|FixNGo|Transit||devtest|
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/availabilitySets/T1PDLZ4QE9C-AV|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/availabilitySets/T1PDLZ4QE9C-AV|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/availabilitySets/T1PRWUXT5N9-AV|NOMIS|BI|test|T1|NOMIS Combined Reporting Testing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/availabilitySets/T1PWL1KW5M1-AV|NOMIS|BI|mid|T1|NOMIS Combined Reporting BOE SAP
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/availabilitySets/T1PWL1NTVQX-AV|NOMIS|BI|web|T1|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-DataDisk-0|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-DataDisk-1|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-DataDisk-2|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-OSDisk|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-DataDisk-0|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-DataDisk-1|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-DataDisk-2|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PDLZ4QE9C0001-OSDisk|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PRWUXT5N90001-DataDisk-0|NOMIS|BI|test|T1|NOMIS Combined Reporting Testing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PRWUXT5N90001-DataDisk-1|NOMIS|BI|test|T1|NOMIS Combined Reporting Testing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PRWUXT5N90001-OSDisk|NOMIS|BI|test|T1|NOMIS Combined Reporting Testing
@@ -54,15 +54,15 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PWL1KW5M10001-OSDisk|NOMIS|BI|mid|T1|NOMIS Combined Reporting BOE SAP
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PWL1NTVQX0001-DataDisk-0|NOMIS|BI|web|T1|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Compute/disks/T1PWL1NTVQX0001-OSDisk|NOMIS|BI|web|T1|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-t1/providers/Microsoft.Compute/virtualMachines/T1PDLZ4QE9C0001|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-t1/providers/Microsoft.Compute/virtualMachines/T1PDLZ4QE9C0001|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-t1/providers/Microsoft.Compute/virtualMachines/T1PRWUXT5N90001|NOMIS|BI|test|T1|NOMIS Combined Reporting Testing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-t1/providers/Microsoft.Compute/virtualMachines/T1PWL1KW5M10001|NOMIS|BI|mid|T1|NOMIS Combined Reporting BOE SAP
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-t1/providers/Microsoft.Compute/virtualMachines/T1PWL1NTVQX0001|NOMIS|BI|web|T1|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Network/networkInterfaces/T1PDLZ4QE9C0001-nic|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Network/networkInterfaces/T1PDLZ4QE9C0001-nic|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Network/networkInterfaces/T1PRWUXT5N90001-nic|NOMIS|BI|test|T1|NOMIS Combined Reporting Testing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Network/networkInterfaces/T1PWL1KW5M10001-nic|NOMIS|BI|mid|T1|NOMIS Combined Reporting BOE SAP
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Network/networkInterfaces/T1PWL1NTVQX0001-nic|NOMIS|BI|web|T1|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Storage/storageAccounts/t1pdlz4qe9cbootdiags|NOMIS|BI|data|T1|NOMIS BIP Oracle DB
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Storage/storageAccounts/t1pdlz4qe9cbootdiags|NOMIS|BI|data|T1|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Storage/storageAccounts/t1prwuxt5n9bootdiags|NOMIS|BI|test|T1|NOMIS Combined Reporting Testing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Storage/storageAccounts/t1pwl1kw5m1bootdiags|NOMIS|BI|mid|T1|NOMIS Combined Reporting BOE SAP
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomis-bip-T1/providers/Microsoft.Storage/storageAccounts/t1pwl1ntvqxbootdiags|NOMIS|BI|web|T1|NOMIS Combined Reporting WebServer (Tomcat 9)
@@ -70,9 +70,11 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/availabilitySets/MGMRLR-as|FixNGo|Management|sshbastion|devtest|jumpbox ssh Bastion primary
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/availabilitySets/MGMRWD-as|FixNGo|Management|remotedesktop|devtest|RD jump server 6 (BO client tools)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/availabilitySets/MGPRW4RI2SN-AV|NOMIS|NOMIS|test|devtest|Client Access Testing
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/availabilitySets/NOMS-Mgmt-JumpServer-Test-AS1|FixNGo|Management|misc|devtest|Shared Access File Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/noms-mgmt/providers/Microsoft.Compute/availabilitySets/NOMS-Mgmt-JumpServer-Test-AS1|FixNGo|Management|misc|devtest|Shared Access File Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMCW0002-DISK1restore20171025|FixNGo|Management|domaincontroller|devtest|AD Server 1; NTP Source
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMCW0002-OS-DISKrestore20171025|FixNGo|Management|domaincontroller|devtest|AD Server 1; NTP Source
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-MGMT/providers/Microsoft.Compute/disks/MGMCW0015-DISK1_b70b1eab9cad4660a2c443b5dc00aa45|FixNGo|Management|misc|devtest|Shared Access File Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-MGMT/providers/Microsoft.Compute/disks/MGMCW0015_29ae65336376469e95668ce15c01ae5a|FixNGo|Management|misc|devtest|Shared Access File Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMNW0030_974a00bb9ac146df97645a5fb27ccce3|FixNGo|Management|utility|devtest|wsus reachback facing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMNW0030_DATA2_677284B848534B2FBAB7E33AA78C0205|FixNGo|Management|utility|devtest|wsus reachback facing
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMNW0030_DATA3_FEBD405D2FFF4AA48066724E5C23D26D|FixNGo|Management|utility|devtest|wsus reachback facing
@@ -90,6 +92,9 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMRLFFQKXR0001-DataDisk-1|FixNGo|Management|sshbastion|devtest|jumpbox ssh Bastion DR
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMRLFFQKXR0001-OSDisk|FixNGo|Management|sshbastion|devtest|jumpbox ssh Bastion DR
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-MGMT/providers/Microsoft.Compute/disks/MGMRW0001_3c591ab9dd3e4bbe9b8adc51cc752b78|FixNGo|Management|remotedesktop|devtest|RD gateway server and web access
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-MGMT/providers/Microsoft.Compute/disks/MGMRW0006_e34efd9512ad449ab661254b7c51e5b9|FixNGo|Management|remotedesktop|devtest|RD jump server 1 (DevOps)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-MGMT/providers/Microsoft.Compute/disks/MGMRW0007_be658eb8b1524972a13aad5cf1a0f713|FixNGo|Management|remotedesktop|devtest|RD jump server 2 (General access 1)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-MGMT/providers/Microsoft.Compute/disks/MGMRW0008_d8c18f15858e49ea911727407c26bc35|FixNGo|Management|remotedesktop|devtest|RD jump server 3 (General access 2)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMRW0011data001|FixNGo|Management|remotedesktop|devtest|RD jump server 6 (BO client tools)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMRW0011data002|FixNGo|Management|remotedesktop|devtest|RD jump server 6 (BO client tools)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Mgmt/providers/Microsoft.Compute/disks/MGMRW0011root001|FixNGo|Management|remotedesktop|devtest|RD jump server 6 (BO client tools)
@@ -148,7 +153,7 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Test/providers/Microsoft.Compute/disks/TCMNL00010_root001|FixNGo|Management|misc|T3|Oracle OEM Server monitoring
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Test/providers/Microsoft.Compute/disks/TCMNL0010-DISK1|FixNGo|Management|misc|T3|Oracle OEM Server monitoring
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-Test/providers/Microsoft.Compute/disks/TCMNL0010-DISK2|FixNGo|Management|misc|T3|Oracle OEM Server monitoring
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/noms-test/providers/Microsoft.Compute/virtualMachines/TCMNL00010|FixNGo|Management|misc|T3|Oracle OEM Server monitoring
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMS-TEST/providers/Microsoft.Compute/virtualMachines/TCMNL00010|FixNGo|Management|misc|T3|Oracle OEM Server monitoring
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/noms-test/providers/Microsoft.Network/networkInterfaces/TCMNL00010-nic|FixNGo|Management|misc|T3|Oracle OEM Server monitoring
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMSMgmt-Proxy/providers/Microsoft.Compute/availabilitySets/MGMLX0051AvailSet|FixNGo|Transit|network|devtest|fortinet NGFW devtest proxy
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/NOMSMgmt-Proxy/providers/Microsoft.Compute/disks/MGMLX0051_disk2_c65039b56fd84bf8bb62230f7750b931|FixNGo|Transit|network|devtest|fortinet NGFW devtest proxy
@@ -158,12 +163,12 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomsmgmt-proxy/providers/Microsoft.Network/networkInterfaces/MGMLX0051Nic1|FixNGo|Transit|network|devtest|fortinet NGFW devtest proxy
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomsmgmt-proxy/providers/Microsoft.Network/publicIPAddresses/Delius_NDH_Inbound|FixNGo|Transit|network|devtest|fortinet NGFW devtest proxy
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/nomsmgmt-proxy/providers/Microsoft.Network/publicIPAddresses/publicip-fortigate|FixNGo|Transit|network|devtest|fortinet NGFW devtest proxy
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/SDPDLCNODB-as|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/SDPDLCNODB-as|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOM)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/SDPNLD-as|NOMIS|NOMIS|network|syscon|Syscon build and store releases here
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/SDPWLCNOMA-as|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPDL0001data001|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPDL0001data002|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPDL0001root001|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPDL0001data001|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPDL0001data002|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPDL0001root001|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOM)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPNL0001data001|NOMIS|NOMIS|network|syscon|Syscon build and store releases here
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPNL0001data002|NOMIS|NOMIS|network|syscon|Syscon build and store releases here
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPNL0001root001|NOMIS|NOMIS|network|syscon|Syscon build and store releases here
@@ -182,14 +187,14 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPWL0005data001|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPWL0005data002|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/disks/SDPWL0005root001|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Compute/virtualMachines/SDPDL0001|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Compute/virtualMachines/SDPDL0001|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOM)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Compute/virtualMachines/SDPNL0001|NOMIS|NOMIS|network|syscon|Syscon build and store releases here
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/SDPWL0001|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/SDPWL0002|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/SDPWL0003|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/SDPWL0004|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/SD-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/SDPWL0005|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Network/networkInterfaces/SDPDL0001-nic|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Network/networkInterfaces/SDPDL0001-nic|NOMIS|NOMIS|data|syscon|C-NOMIS Oracle DB (CNOM)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Network/networkInterfaces/SDPNL0001-nic|NOMIS|NOMIS|network|syscon|Syscon build and store releases here
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Network/networkInterfaces/SDPWL0001-nic|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/sd-prisonnomis/providers/Microsoft.Network/networkInterfaces/SDPWL0002-nic|NOMIS|NOMIS|web|syscon|General Purpose Application Server for Dev Env
@@ -220,11 +225,20 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-noncore/providers/Microsoft.Network/networkInterfaces/T1RDW0001-nic-40e95e3e66a54943be38d2acc2189a96|NonCore|NonCore|data|T1|NonCoreApps MS SQL Server (Branston Staff Files/Offloc)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-noncore/providers/Microsoft.Network/networkInterfaces/T1RDW0002-nic|NonCore|NonCore|data|T1|NonCoreApps MS SQL Server 2
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASys/providers/Microsoft.Compute/availabilitySets/DTODW4CANXL-AV|OASys|OASys|mid|T1|BODS Server - 4.2 Upgrade Test
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASys/providers/Microsoft.Compute/availabilitySets/T1-OASys-App-AS|OASys|OASys|mid|T1|OASys BI Publisher
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASys/providers/Microsoft.Compute/availabilitySets/T1-OASys-Client-AS|OASys|OASys|web|T1|OASys Web Server
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASys/providers/Microsoft.Compute/availabilitySets/T1-OASys-DB-AS|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-oasys/providers/Microsoft.Compute/availabilitySets/T1-OASys-App-AS|OASys|OASys|mid|T1|OASys BI Publisher
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/availabilitySets/T1-OASys-Client-AS|OASys|OASys|web|T1|OASys Web Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-oasys/providers/Microsoft.Compute/availabilitySets/T1-OASys-DB-AS|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASys/providers/Microsoft.Compute/disks/DTODW4CANXL0001-DataDisk-0|OASys|OASys|mid|T1|BODS Server - 4.2 Upgrade Test
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/DTODW4CANXL0001-OSDisk|OASys|OASys|mid|T1|BODS Server - 4.2 Upgrade Test
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1OAL0001-APP-DISK1_2e7e4f97df5d42ec9c00b1fe76368fc1|OASys|OASys|web|T1|OASys Web Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1OAL0001_4a11a6c4d8f74fb79444a0ea49e5ed13|OASys|OASys|web|T1|OASys Web Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1ODL0007-APP-DISK1_38bdf95a647941acba76a9cc11e1c6dd|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1ODL0007-APP-DISK2_8dc9d54907584fc08712f58b3a80ac18|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1ODL0007-DISK1_50f792057a4f459388f2e26c385cd7e9|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1ODL0007_18867b3cc0344619b525108a62c53e3f|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1OML0005-APP-DISK1_736d02137366464f8e449b8c16a776c4|OASys|OASys|mid|T1|OASys BI Publisher
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1OML0005-DISK1_8d1caa2b58cd4c6e9a60ea1456662b37|OASys|OASys|mid|T1|OASys BI Publisher
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASYS/providers/Microsoft.Compute/disks/T1OML0005_28cee46662f247d38edc482d1ab70544|OASys|OASys|mid|T1|OASys BI Publisher
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-oasys/providers/Microsoft.Compute/virtualMachines/DTODW4CANXL0001|OASys|OASys|mid|T1|BODS Server - 4.2 Upgrade Test
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-oasys/providers/Microsoft.Compute/virtualMachines/T1OAL0001|OASys|OASys|web|T1|OASys Web Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-oasys/providers/Microsoft.Compute/virtualMachines/T1ODL0007|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
@@ -234,21 +248,21 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-oasys/providers/Microsoft.Network/networkInterfaces/t1odl0007117|OASys|OASys|data|T1|OASys and ONR Oracle DBMS Combined
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-oasys/providers/Microsoft.Network/networkInterfaces/t1oml0005779|OASys|OASys|mid|T1|OASys BI Publisher
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-OASys/providers/Microsoft.Storage/storageAccounts/dtodw4canxlbootdiags|OASys|OASys|mid|T1|BODS Server - 4.2 Upgrade Test
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/availabilitySets/T1-PNOMIS-DB-AS|NOMIS|NOMIS|data|T1|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/availabilitySets/T1-PNOMIS-DB-AS|NOMIS|NOMIS|data|T1|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,ORSYS)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/availabilitySets/T1-PNOMIS-NDH-AS|NOMIS|NDH|mid|T1|NDH EMS Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/T1PMLORBIP-as|NOMIS|OR|mid|T1|OR BIP (keep for BIP 4.2 - ONR Universe migration)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/T1PWLORAPP-as|NOMIS|OR|web|T1|OR AppServer Weblogic (BIP 4.2 - ONR Universe migration)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/disks/T1PAL0001-APP-DISKrestore20171023|NOMIS|NOMIS|web|T1|C-NOMIS AppServer Weblogic
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/disks/T1PAL0001-OS-DISKrestore20171023|NOMIS|NOMIS|web|T1|C-NOMIS AppServer Weblogic
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009-20180730-data2_44abacacc00c48a6b8bf6e7a290d677a|NOMIS|NOMIS|data|T1|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009-20180730-data3_db33501237464421ab84cd3b70449d70|NOMIS|NOMIS|data|T1|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009-APP-DISK1_3b85037a7bad4025acc8a19cecf9c99b|NOMIS|NOMIS|data|T1|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009_b27f1e18fac34f44b97581fc0729bf52|NOMIS|NOMIS|data|T1|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-20180730-disk2_a4034d8f6eb6495d90ee7ad8033de58b|NOMIS|MIS|data|T1|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-20180730-disk3_2072e14bb6e54db29fad917ce2c1fcd2|NOMIS|MIS|data|T1|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-20200504-142816_94c2aea360384fd6a72932d74307ab4f|NOMIS|MIS|data|T1|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-APP-DISK1_47328617ea13451b8f00a2fb3101a909|NOMIS|MIS|data|T1|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010_7f5bf16bc7c04af68fcb2e18b154b094|NOMIS|MIS|data|T1|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009-20180730-data2_44abacacc00c48a6b8bf6e7a290d677a|NOMIS|NOMIS|data|T1|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,ORSYS)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009-20180730-data3_db33501237464421ab84cd3b70449d70|NOMIS|NOMIS|data|T1|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,ORSYS)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009-APP-DISK1_3b85037a7bad4025acc8a19cecf9c99b|NOMIS|NOMIS|data|T1|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,ORSYS)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0009_b27f1e18fac34f44b97581fc0729bf52|NOMIS|NOMIS|data|T1|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,ORSYS)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-20180730-disk2_a4034d8f6eb6495d90ee7ad8033de58b|NOMIS|MIS|data|T1|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-20180730-disk3_2072e14bb6e54db29fad917ce2c1fcd2|NOMIS|MIS|data|T1|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-20200504-142816_94c2aea360384fd6a72932d74307ab4f|NOMIS|MIS|data|T1|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010-APP-DISK1_47328617ea13451b8f00a2fb3101a909|NOMIS|MIS|data|T1|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PDL0010_7f5bf16bc7c04af68fcb2e18b154b094|NOMIS|MIS|data|T1|MIS and Audit Oracle DB (MIS,CNMAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/disks/T1PML0004-APP-DISK1-restore2-20171109|NOMIS|NDH|mid|T1|NDH Admin Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/disks/T1PML0004-restore2-20171109|NOMIS|NDH|mid|T1|NDH Admin Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/disks/T1PML0005-APP-DISK1_3f16c50ca800480eaa05721aef8737e5|NOMIS|NDH|mid|T1|NDH EMS Tibco Node1
@@ -260,15 +274,15 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/disks/T1PWL0003data002|NOMIS|OR|web|T1|OR AppServer Weblogic (BIP 4.2 - ONR Universe migration)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PrisonNOMIS/providers/Microsoft.Compute/disks/T1PWL0003root001|NOMIS|OR|web|T1|OR AppServer Weblogic (BIP 4.2 - ONR Universe migration)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Compute/virtualMachines/T1PAL0001|NOMIS|NOMIS|web|T1|C-NOMIS AppServer Weblogic
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/virtualMachines/T1PDL0009|NOMIS|NOMIS|data|T1|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/virtualMachines/T1PDL0010|NOMIS|MIS|data|T1|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/virtualMachines/T1PDL0009|NOMIS|NOMIS|data|T1|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,ORSYS)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/virtualMachines/T1PDL0010|NOMIS|MIS|data|T1|MIS and Audit Oracle DB (MIS,CNMAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/virtualMachines/T1PML0004|NOMIS|NDH|mid|T1|NDH Admin Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T1-PRISONNOMIS/providers/Microsoft.Compute/virtualMachines/T1PML0005|NOMIS|NDH|mid|T1|NDH EMS Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Compute/virtualMachines/T1PML0009|NOMIS|OR|mid|T1|OR BIP (keep for BIP 4.2 - ONR Universe migration)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Compute/virtualMachines/T1PWL0003|NOMIS|OR|web|T1|OR AppServer Weblogic (BIP 4.2 - ONR Universe migration)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/t1pal0001444|NOMIS|NOMIS|web|T1|C-NOMIS AppServer Weblogic
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/t1pdl0009708|NOMIS|NOMIS|data|T1|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/t1pdl0010743|NOMIS|MIS|data|T1|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/t1pdl0009708|NOMIS|NOMIS|data|T1|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,ORSYS)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/t1pdl0010743|NOMIS|MIS|data|T1|MIS and Audit Oracle DB (MIS,CNMAUD)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/t1pml0004719|NOMIS|NDH|mid|T1|NDH Admin Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/t1pml0005882|NOMIS|NDH|mid|T1|NDH EMS Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t1-prisonnomis/providers/Microsoft.Network/networkInterfaces/T1PML0009-nic|NOMIS|OR|mid|T1|OR BIP (keep for BIP 4.2 - ONR Universe migration)
@@ -284,8 +298,17 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASys/providers/Microsoft.Compute/disks/t2oal0002-osdisk-20220124-124934|OASys|OASys|web|T2|OASys Web Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OAL0003-APP-DISK1_1ad3a12c409244c29f0c991ce30b6258|OASys|ONR|web|T2|ONR Web Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OAL0003_794299373f764015a2961d0b97834e75|OASys|ONR|web|T2|ONR Web Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2ODL0009-APP-DISK1_cad5a1d6622244b19f992227cf9f1d4f|OASys|OASys|data|T2|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2ODL0009-DISK1_82894b7c72214817936e1683d94ff430|OASys|OASys|data|T2|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2ODL0009_02e36c55e9a9402b831a44e0dd86fd75|OASys|OASys|data|T2|OASys and ONR Oracle DBMS Combined
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OML0005-APP-DISK1_cc5cf855405e4acca106a160791eb891|OASys|OASys|mid|T2|BOE SAP
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OML0005_ca11ae5553e54de4ada8e555810fe034|OASys|OASys|mid|T2|BOE SAP
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OML0007-APP-DISK1_41bba9a5a01540558658803b1ea50482|OASys|OASys|mid|T2|OASys BI Publisher
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OML0007_408d728402f34015a6ae14b6a5fc7935|OASys|OASys|mid|T2|OASys BI Publisher
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OMW0006-APP-DISK1_afc8d1456f014b4b943c4e7832f2fb45|OASys|OASys|mid|T2|BODS Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OMW0006-APP-DISK2_0d5df87cb7224e10bc1b3613a391dc48|OASys|OASys|mid|T2|BODS Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OMW0006-DISK1_f6a2723a72894aa492a569d9bc2c768b|OASys|OASys|mid|T2|BODS Server
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-OASYS/providers/Microsoft.Compute/disks/T2OMW0006_edb24644e9a949b8a1c94e18a81c05f6|OASys|OASys|mid|T2|BODS Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-oasys/providers/Microsoft.Compute/virtualMachines/T2OAL0001|OASys|OASys|web|T2|OASys Web Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-oasys/providers/Microsoft.Compute/virtualMachines/T2OAL0002|OASys|OASys|web|T2|OASys Web Server
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-oasys/providers/Microsoft.Compute/virtualMachines/T2OAL0003|OASys|ONR|web|T2|ONR Web Server
@@ -300,19 +323,26 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-oasys/providers/Microsoft.Network/networkInterfaces/t2oml0005804|OASys|OASys|mid|T2|BOE SAP
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-oasys/providers/Microsoft.Network/networkInterfaces/t2oml0007949|OASys|OASys|mid|T2|OASys BI Publisher
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-oasys/providers/Microsoft.Network/networkInterfaces/t2omw0006168|OASys|OASys|mid|T2|BODS Server
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/T2-PNOMIS-NDH-AS|NOMIS|NDH|mid|T2|NDH Admin Tibco Node1
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/availabilitySets/T2-PNOMIS-NDH-AS|NOMIS|NDH|mid|T2|NDH Admin Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PrisonNOMIS/providers/Microsoft.Compute/disks/T2PAL0040-APP-DISK1|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PrisonNOMIS/providers/Microsoft.Compute/disks/T2PAL0040_OsDisk_1_28d7765c356f4bb79975ea67512debac|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PrisonNOMIS/providers/Microsoft.Compute/disks/T2PAL0041-APP-DISK1|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PrisonNOMIS/providers/Microsoft.Compute/disks/T2PAL0041_OsDisk_1_8415cf9a15834289957d750a5052dab8|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/disks/t2pdl0012-datadisk-000-20200826-080812_4feb5b87eba74a5ab601ad756c9669d0|NOMIS|NOMIS|data|T2|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/disks/t2pdl0012-datadisk-001-20200826-080812_73f87c1966dd496ca7fc4174b70c39d2|NOMIS|NOMIS|data|T2|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/disks/t2pdl0012-osdisk-20200826-080812_5e807a3abaaa43d19be71556479fc0bb|NOMIS|NOMIS|data|T2|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/disks/T2PML0007-APP-DISK1_b42af013ed934dc0b669b1644cf6f2bc|NOMIS|NDH|mid|T2|NDH Admin Tibco Node1
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/disks/T2PML0007_dc16a8717ab349f0ab62aef51aa2bca3|NOMIS|NDH|mid|T2|NDH Admin Tibco Node1
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/disks/T2PML0008-APP-DISK1_ea0385ab2be442208e4900c96f31ca8e|NOMIS|NDH|mid|T2|NDH EMS Tibco Node1
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PRISONNOMIS/providers/Microsoft.Compute/disks/T2PML0008_2d3827d0a994476eb1caa02234e75cff|NOMIS|NDH|mid|T2|NDH EMS Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/T2PAL0040|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T2-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/T2PAL0041|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Compute/virtualMachines/T2PDL0012|NOMIS|NOMIS|data|T2|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Compute/virtualMachines/T2PDL0012|NOMIS|NOMIS|data|T2|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Compute/virtualMachines/T2PML0007|NOMIS|NDH|mid|T2|NDH Admin Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Compute/virtualMachines/T2PML0008|NOMIS|NDH|mid|T2|NDH EMS Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Network/networkInterfaces/t2pal0040464|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Network/networkInterfaces/t2pal0041998|NOMIS|NOMIS|web|T2|C-NOMIS AppServer Weblogic
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Network/networkInterfaces/T2PDL0012-nic-97ef0d7b2a234df4895dcb60e93981ff|NOMIS|NOMIS|data|T2|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Network/networkInterfaces/T2PDL0012-nic-97ef0d7b2a234df4895dcb60e93981ff|NOMIS|NOMIS|data|T2|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Network/networkInterfaces/t2pml0007365|NOMIS|NDH|mid|T2|NDH Admin Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t2-prisonnomis/providers/Microsoft.Network/networkInterfaces/t2pml0008565|NOMIS|NDH|mid|T2|NDH EMS Tibco Node1
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-CSR/providers/Microsoft.Compute/disks/T3CDL0021-APP-DISK1|CSR|CSR|data|T3|Oracle Database 2 (High Availability / Data Guard)
@@ -329,16 +359,19 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-CSR/providers/Microsoft.Compute/disks/t3cdl0021_os|CSR|CSR|data|T3|Oracle Database 2 (High Availability / Data Guard)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-CSR/providers/Microsoft.Compute/virtualMachines/T3CDL0021|CSR|CSR|data|T3|Oracle Database 2 (High Availability / Data Guard)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t3-csr/providers/Microsoft.Network/networkInterfaces/t3cdl0021149|CSR|CSR|data|T3|Oracle Database 2 (High Availability / Data Guard)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/T3P-DB-AS1|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/T3PWLCNOMA-as|NOMIS|NOMIS|web|T3|C-NOMIS AppServer Weblogic
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-APP-DISK1|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDl0070-DISK13|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-DISK15|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-DISK16|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-DISK17|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070_DAZbacku_Copy|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t3-prisonnomis/providers/Microsoft.Compute/virtualMachines/T3PDL0070|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/availabilitySets/T3P-DB-AS1|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PRISONNOMIS/providers/Microsoft.Compute/availabilitySets/T3PWLCNOMA-as|NOMIS|NOMIS|web|T3|C-NOMIS AppServer Weblogic
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-APP-DISK1|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDl0070-DISK13|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-DISK15|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-DISK16|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070-DISK17|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/disks/T3PDL0070_DAZbacku_Copy|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PRISONNOMIS/providers/Microsoft.Compute/disks/T3PWL00001_data001_199eaa5c8070482fb0db9119611ea262|NOMIS|NOMIS|web|T3|C-NOMIS AppServer Weblogic
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PRISONNOMIS/providers/Microsoft.Compute/disks/T3PWL00001_data002_a9d6df0fe23e47dc8daa89b1416fcfef|NOMIS|NOMIS|web|T3|C-NOMIS AppServer Weblogic
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PRISONNOMIS/providers/Microsoft.Compute/disks/T3PWL00001_root001_e780ff3a2af14a1c95cd86bb5775349a|NOMIS|NOMIS|web|T3|C-NOMIS AppServer Weblogic
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t3-prisonnomis/providers/Microsoft.Compute/virtualMachines/T3PDL0070|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/T3-PrisonNOMIS/providers/Microsoft.Compute/virtualMachines/T3PWL00001|NOMIS|NOMIS|web|T3|C-NOMIS AppServer Weblogic
-/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t3-prisonnomis/providers/Microsoft.Network/networkInterfaces/t3pdl0070283|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t3-prisonnomis/providers/Microsoft.Network/networkInterfaces/t3pdl0070283|NOMIS|NOMIS|data|T3|C-NOMIS Oracle DB (CNOM)
 /subscriptions/b1f3cebb-4988-4ff9-9259-f02ad7744fcb/resourceGroups/t3-prisonnomis/providers/Microsoft.Network/networkInterfaces/T3PWL00001-nic|NOMIS|NOMIS|web|T3|C-NOMIS AppServer Weblogic

--- a/tags/NOMSProduction1/service_app_component_env_desc/inherit.AzureDSO.resourcestags.txt
+++ b/tags/NOMSProduction1/service_app_component_env_desc/inherit.AzureDSO.resourcestags.txt
@@ -1,8 +1,8 @@
 id|tags.service|tags.application|tags.component|tags.environment_name|tags.description
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/LSPDL0070-DISK21|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/LSPDL0071-DISK21|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/PPPDL00016-DISK22|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/PPPDL00017-DISK21|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/LSPDL0070-DISK21|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/LSPDL0071-DISK21|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/PPPDL00016-DISK22|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/azureconsupmtion/providers/Microsoft.Compute/disks/PPPDL00017-DISK21|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-OASys/providers/Microsoft.Compute/availabilitySets/DRODLOASOD-as|OASys|OASys|data|DR|OASys Oracle DBMS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-OASys/providers/Microsoft.Compute/availabilitySets/DROMLOABIP-as|OASys|OASys|mid|DR|OASys BI Publisher
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-OASys/providers/Microsoft.Compute/availabilitySets/DROWLOASHA1-as|OASys|OASys|ha|DR|OASys HA Proxy Node1
@@ -73,32 +73,32 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-oasys/providers/Microsoft.Network/networkInterfaces/DROWL10031-nic|OASys|OASys|ha|DR|OASys HA Proxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-oasys/providers/Microsoft.Network/networkInterfaces/DROWL10032-nic|OASys|ONR|ha|DR|ONR HA Proxy Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-oasys/providers/Microsoft.Network/networkInterfaces/DROWL10033-nic|OASys|ONR|ha|DR|ONR HA Proxy Node2
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPDLPNDB1-as|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPDLPNDB2-as|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPDLPNDB1-as|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPDLPNDB2-as|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPDWPNWFS-as|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPMLNDHAP-as|NOMIS|NDH|mid|DR|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPMLNDHEM-as|NOMIS|NDH|mid|DR|NDH EMS Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPMWNDHDS-as|NOMIS|NDH|mid|DR|NDH Windows Distribution Server
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPWLCNOMA-as|NOMIS|NOMIS|web|DR|C-NOMIS AppServer Weblogic
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/DRPWLPNOMHA1-as|NOMIS|NOMIS|ha|DR|C-NOMIS HAProxy Node1
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-15|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-16|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-17|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-18|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036_data001-restore-20171110|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036_data002-restore-20171110|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036_root001-restore-20171110|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037-NEWDISK-ASM-10|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037-NEWDISK-ASM-11|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037-NEWDISK-ASM-12|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037_data001|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037_data002|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037_root001|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038-DISK1|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038-DISK2|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038_data001|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038_data002|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038_root001|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-15|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-16|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-17|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036-NEWDISK-ASM-18|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036_data001-restore-20171110|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036_data002-restore-20171110|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10036_root001-restore-20171110|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037-NEWDISK-ASM-10|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037-NEWDISK-ASM-11|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037-NEWDISK-ASM-12|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037_data001|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037_data002|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10037_root001|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038-DISK1|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038-DISK2|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038_data001|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038_data002|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDL10038_root001|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDW10046-DISK1|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDW10046-DISK2|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPDW10046-DISK3|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
@@ -163,9 +163,9 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPWL10052_data001|NOMIS|NOMIS|ha|DR|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPWL10052_data002|NOMIS|NOMIS|ha|DR|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/DR-Prison-NOMIS/providers/Microsoft.Compute/disks/DRPWL10052_root001|NOMIS|NOMIS|ha|DR|C-NOMIS HAProxy Node2
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDL10036|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDL10037|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDL10038|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDL10036|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDL10037|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDL10038|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDW10046|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPDW10057|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPML10025|NOMIS|NDH|mid|DR|NDH Admin Tibco Node1
@@ -184,9 +184,9 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPWL10051|NOMIS|NOMIS|ha|DR|C-NOMIS HAProxy Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Compute/virtualMachines/DRPWL10052|NOMIS|NOMIS|ha|DR|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/loadBalancers/DR-PrisonNOMIS-NOMIS-LB1|NOMIS|NOMIS|web|DR|
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDL10036-nic|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDL10037-nic|NOMIS|MIS|data|DR|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDL10038-nic|NOMIS|NDH|data|DR|NDH Oracle DB (NDHP,TRDATP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDL10036-nic|NOMIS|NOMIS|data|DR|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDL10037-nic|NOMIS|MIS|data|DR|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDL10038-nic|NOMIS|NDH|data|DR|NDH Oracle DB (NDH,TRDAT)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDW10046-nic|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPDW10057-nic|NOMIS|NOMIS|data|DR|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/dr-prison-nomis/providers/Microsoft.Network/networkInterfaces/DRPML10025-nic|NOMIS|NDH|mid|DR|NDH Admin Tibco Node1
@@ -211,24 +211,24 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/hmpps-prod-ukwest-appgw-rg/providers/Microsoft.Network/applicationGateways/hmpps-prod-ukwest-appgw1|FixNGo|Transit||prod|
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/hmpps-prod-ukwest-appgw-rg/providers/Microsoft.Network/applicationGateways/hmpps-prod-ukwest-appgw2|FixNGo|Transit||prod|
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/hmpps-prod-ukwest-appgw-rg/providers/Microsoft.Network/applicationGateways/hmpps-prod-ukwest-appgw3|FixNGo|Transit||prod|
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/LSPDLPNDB1-as|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/LSPDLPNDB1-as|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/LSPMLNDHAP-as|NOMIS|NDH|mid|lsast|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/LSPMLNDHEM-as|NOMIS|NDH|mid|lsast|NDH EMS Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/LSPWLCNOMA-as|NOMIS|NOMIS|web|lsast|C-NOMIS AppServer Weblogic
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070-NEWDISK-10|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070-NEWDISK-11|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070-NEWDISK-12|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-PRISON-NOMIS/providers/Microsoft.Compute/disks/lspdl00070-newdisk-13|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070data001|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070data002|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070root001|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-10|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-11|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-12|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-13|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071data001|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071data002|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071root001-201804300-disk|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070-NEWDISK-10|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070-NEWDISK-11|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070-NEWDISK-12|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-PRISON-NOMIS/providers/Microsoft.Compute/disks/lspdl00070-newdisk-13|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070data001|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070data002|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00070root001|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-10|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-11|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-12|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071-NEWDISK-13|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071data001|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071data002|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPDL00071root001-201804300-disk|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPML00040data001|NOMIS|NDH|mid|lsast|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPML00040data002|NOMIS|NDH|mid|lsast|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPML00040root001|NOMIS|NDH|mid|lsast|NDH Admin Tibco Node1
@@ -238,13 +238,13 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPWL00011data001|NOMIS|NOMIS|web|lsast|C-NOMIS AppServer Weblogic
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPWL00011data002|NOMIS|NOMIS|web|lsast|C-NOMIS AppServer Weblogic
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/disks/LSPWL00011root001|NOMIS|NOMIS|web|lsast|C-NOMIS AppServer Weblogic
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-PRISON-NOMIS/providers/Microsoft.Compute/virtualMachines/LSPDL00070|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Compute/virtualMachines/LSPDL00071|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-PRISON-NOMIS/providers/Microsoft.Compute/virtualMachines/LSPDL00070|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-PRISON-NOMIS/providers/Microsoft.Compute/virtualMachines/LSPDL00071|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Compute/virtualMachines/LSPML00040|NOMIS|NDH|mid|lsast|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Compute/virtualMachines/LSPML00042|NOMIS|NDH|mid|lsast|NDH EMS Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/LS-Prison-NOMIS/providers/Microsoft.Compute/virtualMachines/LSPWL00011|NOMIS|NOMIS|web|lsast|C-NOMIS AppServer Weblogic
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Network/networkInterfaces/LSPDL00070-nic|NOMIS|NOMIS|data|lsast|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Network/networkInterfaces/LSPDL00071-nic|NOMIS|MIS|data|lsast|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Network/networkInterfaces/LSPDL00070-nic|NOMIS|NOMIS|data|lsast|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT,CNMTRN)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Network/networkInterfaces/LSPDL00071-nic|NOMIS|MIS|data|lsast|MIS Oracle DB (MIS)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Network/networkInterfaces/LSPML00040-nic|NOMIS|NDH|mid|lsast|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Network/networkInterfaces/LSPML00042-nic|NOMIS|NDH|mid|lsast|NDH EMS Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/ls-prison-nomis/providers/Microsoft.Network/networkInterfaces/LSPWL00011-nic|NOMIS|NOMIS|web|lsast|C-NOMIS AppServer Weblogic
@@ -282,16 +282,16 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_ukwest/flowLogs/Microsoft.Networkhmpps-preprod-ukwest-appgw-rghmpps-preprod-ukwest-appgw1-nsg|FixNGo|Transit||preprod|
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_ukwest/flowLogs/Microsoft.Networkhmpps-prod-ukwest-appgw-rghmpps-prod-ukwest-appgw1-nsg|FixNGo|Transit||prod|
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NetworkWatcherRG/providers/Microsoft.Network/networkWatchers/NetworkWatcher_ukwest/flowLogs/Microsoft.Networkhmpps-prod-ukwest-appgw-rghmpps-prod-ukwest-appgw2-nsg|FixNGo|Transit||prod|
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/availabilitySets/LSPDLHQX33I-AV|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/availabilitySets/LSPDLHQX33I-AV|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/availabilitySets/LSPMLIA64CU-AV|NOMIS|BI|mid|lsast|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/availabilitySets/LSPMWRZ10YV-AV|NOMIS|BI|mid|lsast|NOMIS MIS-ETL IPS/BODS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/availabilitySets/LSPRWRFDBP8-AV|NOMIS|BI|test|lsast|NOMIS Combined Reporting Testing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/availabilitySets/LSPWLJZ5Q4L-AV|NOMIS|BI|web|lsast|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-DataDisk-0|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-DataDisk-1|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-DataDisk-2|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/lspdlhqx33i0001-datadisk-3|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-OSDisk|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-DataDisk-0|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-DataDisk-1|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-DataDisk-2|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/lspdlhqx33i0001-datadisk-3|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPDLHQX33I0001-OSDisk|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPMLIA64CU0001-DataDisk-0|NOMIS|BI|mid|lsast|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPMLIA64CU0001-DataDisk-1|NOMIS|BI|mid|lsast|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPMLIA64CU0001-OSDisk|NOMIS|BI|mid|lsast|NOMIS Combined Reporting BOE SAP
@@ -304,31 +304,31 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPWLJZ5Q4L0001-DataDisk-0|NOMIS|BI|web|lsast|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPWLJZ5Q4L0001-DataDisk-1|NOMIS|BI|web|lsast|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/disks/LSPWLJZ5Q4L0001-OSDisk|NOMIS|BI|web|lsast|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/virtualMachines/LSPDLHQX33I0001|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/virtualMachines/LSPDLHQX33I0001|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/virtualMachines/LSPMLIA64CU0001|NOMIS|BI|mid|lsast|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/virtualMachines/LSPMWRZ10YV0001|NOMIS|BI|mid|lsast|NOMIS MIS-ETL IPS/BODS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/virtualMachines/LSPRWRFDBP80001|NOMIS|BI|test|lsast|NOMIS Combined Reporting Testing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Compute/virtualMachines/LSPWLJZ5Q4L0001|NOMIS|BI|web|lsast|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Network/networkInterfaces/LSPDLHQX33I0001-nic|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Network/networkInterfaces/LSPDLHQX33I0001-nic|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Network/networkInterfaces/LSPMLIA64CU0001-nic|NOMIS|BI|mid|lsast|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Network/networkInterfaces/LSPMWRZ10YV0001-nic|NOMIS|BI|mid|lsast|NOMIS MIS-ETL IPS/BODS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Network/networkInterfaces/LSPRWRFDBP80001-nic|NOMIS|BI|test|lsast|NOMIS Combined Reporting Testing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Network/networkInterfaces/LSPWLJZ5Q4L0001-nic|NOMIS|BI|web|lsast|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Storage/storageAccounts/lspdlhqx33ibootdiags|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Storage/storageAccounts/lspdlhqx33ibootdiags|NOMIS|BI|data|lsast|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Storage/storageAccounts/lspmlia64cubootdiags|NOMIS|BI|mid|lsast|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Storage/storageAccounts/lspmwrz10yvbootdiags|NOMIS|BI|mid|lsast|NOMIS MIS-ETL IPS/BODS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Storage/storageAccounts/lsprwrfdbp8bootdiags|NOMIS|BI|test|lsast|NOMIS Combined Reporting Testing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-lsast/providers/Microsoft.Storage/storageAccounts/lspwljz5q4lbootdiags|NOMIS|BI|web|lsast|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/availabilitySets/PPPDL2QGCPE-AV|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/availabilitySets/PPPDL2QGCPE-AV|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/availabilitySets/PPPMLH4HUJV-AV|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/availabilitySets/PPPMW0HW7AX-AV|NOMIS|BI|mid|preprod|NOMIS MIS-ETL IPS/BODS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/availabilitySets/PPPWL82SG2D-AV|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/availabilitySets/PPPWLWVE79H-AV|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-DataDisk-0|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-DataDisk-1|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-DataDisk-2|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/pppdl2qgcpe0001-datadisk-3|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-OSDisk|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-DataDisk-0|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-DataDisk-1|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-DataDisk-2|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/pppdl2qgcpe0001-datadisk-3|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPDL2QGCPE0001-OSDisk|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPMLH4HUJV0001-DataDisk-0|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPMLH4HUJV0001-DataDisk-1|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPMLH4HUJV0001-OSDisk|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
@@ -350,7 +350,7 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPWLWVE79H0002-DataDisk-0|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPWLWVE79H0002-DataDisk-1|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/disks/PPPWLWVE79H0002-OSDisk|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPDL2QGCPE0001|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPDL2QGCPE0001|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPMLH4HUJV0001|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPMLH4HUJV0002|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPMLH4HUJV0003|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
@@ -358,7 +358,7 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPWL82SG2D0001|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPWLWVE79H0001|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Compute/virtualMachines/PPPWLWVE79H0002|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPDL2QGCPE0001-nic|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPDL2QGCPE0001-nic|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPMLH4HUJV0001-nic|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPMLH4HUJV0002-nic|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPMLH4HUJV0003-nic|NOMIS|BI|mid|preprod|NOMIS Combined Reporting BOE SAP
@@ -366,23 +366,23 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPWL82SG2D0001-nic|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPWLWVE79H0001-nic|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Network/networkInterfaces/PPPWLWVE79H0002-nic|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Storage/storageAccounts/pppdl2qgcpebootdiags|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Storage/storageAccounts/pppdl2qgcpebootdiags|NOMIS|BI|data|preprod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Storage/storageAccounts/pppmw0hw7axbootdiags|NOMIS|BI|mid|preprod|NOMIS MIS-ETL IPS/BODS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-preprod/providers/Microsoft.Storage/storageAccounts/pppwl82sg2dbootdiags|NOMIS|BI|web|preprod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/availabilitySets/PDPDL39C893-AV|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/availabilitySets/PDPDL39C893-AV|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/availabilitySets/PDPML0TUC0Y-AV|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/availabilitySets/PDPMW0P1UQL-AV|NOMIS|BI|mid|prod|NOMIS MIS-ETL IPS/BODS
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/availabilitySets/PDPWLHMENDT-AV|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/availabilitySets/PDPWLL4YGZA-AV|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-DataDisk-0|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-DataDisk-1|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-DataDisk-2|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/pdpdl39c8930001-datadisk-3|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-OSDisk|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-DataDisk-0|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-DataDisk-1|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-DataDisk-2|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-OSDisk|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-DataDisk-0|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-DataDisk-1|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-DataDisk-2|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/pdpdl39c8930001-datadisk-3|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930001-OSDisk|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-DataDisk-0|NOMIS|BI|data|prod|NOMIS BIP Oracle DB HA
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-DataDisk-1|NOMIS|BI|data|prod|NOMIS BIP Oracle DB HA
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-DataDisk-2|NOMIS|BI|data|prod|NOMIS BIP Oracle DB HA
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPDL39C8930002-OSDisk|NOMIS|BI|data|prod|NOMIS BIP Oracle DB HA
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPML0TUC0Y0001-DataDisk-0|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPML0TUC0Y0001-DataDisk-1|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPML0TUC0Y0001-OSDisk|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
@@ -422,8 +422,8 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPWLL4YGZA0001-DataDisk-0|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPWLL4YGZA0001-DataDisk-1|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/disks/PDPWLL4YGZA0001-OSDisk|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPDL39C8930001|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPDL39C8930002|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPDL39C8930001|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPDL39C8930002|NOMIS|BI|data|prod|NOMIS BIP Oracle DB HA
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPML0TUC0Y0001|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPML0TUC0Y0002|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPML0TUC0Y0003|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
@@ -437,8 +437,8 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPWLHMENDT0003|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPWLHMENDT0004|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Compute/virtualMachines/PDPWLL4YGZA0001|NOMIS|BI|web|prod|NOMIS Combined Reporting WebServer (Tomcat 9) - Admin CMC
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Network/networkInterfaces/PDPDL39C8930001-nic|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Network/networkInterfaces/PDPDL39C8930002-nic|NOMIS|BI|data|prod|NOMIS BIP Oracle DB
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Network/networkInterfaces/PDPDL39C8930001-nic|NOMIS|BI|data|prod|NOMIS BIP Oracle DB (BIPSYS, BIPAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Network/networkInterfaces/PDPDL39C8930002-nic|NOMIS|BI|data|prod|NOMIS BIP Oracle DB HA
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Network/networkInterfaces/PDPML0TUC0Y0001-nic|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Network/networkInterfaces/PDPML0TUC0Y0002-nic|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/nomis-bip-prod/providers/Microsoft.Network/networkInterfaces/PDPML0TUC0Y0003-nic|NOMIS|BI|mid|prod|NOMIS Combined Reporting BOE SAP
@@ -459,6 +459,7 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Live/providers/Microsoft.Compute/disks/PCMCL00041_data004|FixNGo|Management|misc|prod|Oracle OEM Server monitoring
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Live/providers/Microsoft.Compute/disks/pcmcl00041_data005|FixNGo|Management|misc|prod|Oracle OEM Server monitoring
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Live/providers/Microsoft.Compute/disks/PCMCL00041_root001|FixNGo|Management|misc|prod|Oracle OEM Server monitoring
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-LIVE/providers/Microsoft.Compute/disks/PCMCW0051_7f482632b9bd411e9954c70f29f4af32|FixNGo|Management|utility|prod|SMTP gateway server (for Offloc)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-live/providers/Microsoft.Compute/virtualMachines/PCMCL00041|FixNGo|Management|misc|prod|Oracle OEM Server monitoring
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-live/providers/Microsoft.Compute/virtualMachines/PCMCW0051|FixNGo|Management|utility|prod|SMTP gateway server (for Offloc)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-live/providers/Microsoft.Network/networkInterfaces/PCMCL00041-nic|FixNGo|Management|misc|prod|Oracle OEM Server monitoring
@@ -470,7 +471,7 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-live-dr/providers/Microsoft.Compute/virtualMachines/DRMCL10029|FixNGo|Management|misc|DR|Oracle OEM Server monitoring
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-live-dr/providers/Microsoft.Network/networkInterfaces/DRMCL10029-nic|FixNGo|Management|misc|DR|Oracle OEM Server monitoring
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/availabilitySets/PCM-AD-AS1|FixNGo|Management|domaincontroller|prod|AD Server 2; NTP Source
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/availabilitySets/PDMR2WD-as|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/availabilitySets/PDMR2WD-as|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/availabilitySets/PDMRLR-as|FixNGo|Management|sshbastion|prod|jumpbox ssh Bastion primary
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/availabilitySets/PDMRWD-as|FixNGo|Management|remotedesktop|prod|RD jump server 2 (General access 1)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/availabilitySets/PDPRWZLQ6Z1-AV|NOMIS|NOMIS|test|prod|Client Access Testing
@@ -484,6 +485,12 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMNW0041-APP-DISK2|FixNGo|Management|utility|prod|wsus internal facing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMNW0041_DATA1_74E3CBED5B4B4ED79AE4B08A522B5154|FixNGo|Management|utility|prod|wsus internal facing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMNW0041_OsDisk_1_fa486142eed04c03a0093128ee142aa3|FixNGo|Management|utility|prod|wsus internal facing
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMR2W00011_data001_2390ae28d9a34570978196c540147bbf|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMR2W00011_data002_7a9bf2ab707d4fd3b5eb711ebda71ee7|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMR2W00011_root001_6eeeef4d37b341e3912ec0bf3d3d7e82|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMR2W00014_data001_4368841225764a9f93141744eec7a267|FixNGo|Management|remotedesktop|prod|RD jump server 8 (NART Interface Access)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMR2W00014_data002_b567e53c48464abaaa992e8cec0a29c0|FixNGo|Management|remotedesktop|prod|RD jump server 8 (NART Interface Access)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMR2W00014_root001_2c663e3ae6b7458192afa898897ff99d|FixNGo|Management|remotedesktop|prod|RD jump server 8 (NART Interface Access)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMRL00109data001|FixNGo|Management|sshbastion|prod|jumpbox ssh Bastion primary
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMRL00109data002|FixNGo|Management|sshbastion|prod|jumpbox ssh Bastion primary
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMRL00109root001|FixNGo|Management|sshbastion|prod|jumpbox ssh Bastion primary
@@ -504,11 +511,17 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMRW00009_PDMRW00009-DISK5|FixNGo|Management|remotedesktop|prod|RD jump server 4 (DBA)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMRW00009_PDMRW00009-DISK6|FixNGo|Management|remotedesktop|prod|RD jump server 4 (DBA)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Compute/disks/PDMRW00009_root001|FixNGo|Management|remotedesktop|prod|RD jump server 4 (DBA)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMRW0001_ee379379f16645aca0d751f8b2432c3c|FixNGo|Management|remotedesktop|prod|RD gateway server and web access
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMRW0002-20170609-093650_2f992610d08f44e4ab0813ed03a79c6a|FixNGo|Management|remotedesktop|prod|RD session host
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMRW0002_98313826b61e4e5a905ef9b6a3191cbe|FixNGo|Management|remotedesktop|prod|RD session host
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMRW0003-20170609-100115_dd8dcd6aace74a32b2138a069cb998c4|FixNGo|Management|remotedesktop|prod|RD connection broker
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMRW0003_d1a1ef063de4447e930739db15b7d32e|FixNGo|Management|remotedesktop|prod|RD connection broker
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDMRW0004_3d988beba9f743269b5de50bb2d5b9cb|FixNGo|Management|remotedesktop|prod|RD licensing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/disks/PDPRWZLQ6Z10001-OSDisk|NOMIS|NOMIS|test|prod|Client Access Testing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PCMCW0011|FixNGo|Management|domaincontroller|prod|AD Server 1; NTP Source
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PCMCW0012|FixNGo|Management|domaincontroller|prod|AD Server 2; NTP Source
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDMNW0041|FixNGo|Management|utility|prod|wsus internal facing
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDMR2W00011|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE/providers/Microsoft.Compute/virtualMachines/PDMR2W00011|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDMR2W00014|FixNGo|Management|remotedesktop|prod|RD jump server 8 (NART Interface Access)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDMRL00109|FixNGo|Management|sshbastion|prod|jumpbox ssh Bastion primary
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDMRW00007|FixNGo|Management|remotedesktop|prod|RD jump server 2 (General access 1)
@@ -519,7 +532,7 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDMRW0003|FixNGo|Management|remotedesktop|prod|RD connection broker
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDMRW0004|FixNGo|Management|remotedesktop|prod|RD licensing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Compute/virtualMachines/PDPRWZLQ6Z10001|NOMIS|NOMIS|test|prod|Client Access Testing
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Network/networkInterfaces/pcmcw001163|FixNGo|Management|domaincontroller|prod|AD Server 1; NTP Source
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Network/networkInterfaces/pcmcw001163|FixNGo|Management|domaincontroller|prod|AD Server 1; NTP Source
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Network/networkInterfaces/pcmcw0012231|FixNGo|Management|domaincontroller|prod|AD Server 2; NTP Source
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Network/networkInterfaces/pdmnw0041369|FixNGo|Management|utility|prod|wsus internal facing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live/providers/Microsoft.Network/networkInterfaces/PDMR2W00011-nic|FixNGo|Management|remotedesktop|prod|RD jump server (NOMIS IE & Java)
@@ -535,13 +548,22 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Network/networkInterfaces/PDPRWZLQ6Z10001-nic|NOMIS|NOMIS|test|prod|Client Access Testing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live/providers/Microsoft.Storage/storageAccounts/pdprwzlq6z1bootdiags|NOMIS|NOMIS|test|prod|Client Access Testing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/availabilitySets/DRMRWRDJPS-as|FixNGo|Management|remotedesktop|DR|RD jump server 2 (General access 1)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/availabilitySets/DRMRWRDSCB-as|FixNGo|Management|remotedesktop|DR|RD connection broker
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live-dr/providers/Microsoft.Compute/availabilitySets/DRMRWRDSCB-as|FixNGo|Management|remotedesktop|DR|RD connection broker
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/availabilitySets/DRMRWRDSGW-AS1|FixNGo|Management|remotedesktop|DR|RD gateway server and web access
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/availabilitySets/DRMRWRDSLS-as|FixNGo|Management|remotedesktop|DR|RD licensing
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/availabilitySets/DRMRWRDSSSH-as|FixNGo|Management|remotedesktop|DR|RD session host
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live-dr/providers/Microsoft.Compute/availabilitySets/DRMRWRDSLS-as|FixNGo|Management|remotedesktop|DR|RD licensing
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/noms-mgmt-live-dr/providers/Microsoft.Compute/availabilitySets/DRMRWRDSSSH-as|FixNGo|Management|remotedesktop|DR|RD session host
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/disks/DRMRW10001-restore-20171026|FixNGo|Management|remotedesktop|DR|RD gateway server and web access
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/disks/DRMRW10001data1-restore-20171026|FixNGo|Management|remotedesktop|DR|RD gateway server and web access
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/disks/DRMRW10001data2-restore-20171026|FixNGo|Management|remotedesktop|DR|RD gateway server and web access
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10002_data001_89b01bcb31b14309b1a32894ab06ba50|FixNGo|Management|remotedesktop|DR|RD session host
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10002_data002_e76d06636cd64a6eb13e7f0c7b180024|FixNGo|Management|remotedesktop|DR|RD session host
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10002_root001_fe8955108a1a4e0a91906249903a4770|FixNGo|Management|remotedesktop|DR|RD session host
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10003_data001_8b126d0c05cd461ca62d80e159b7ebeb|FixNGo|Management|remotedesktop|DR|RD connection broker
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10003_data002_59c74c762cc84ef5a3a38ba7bd641569|FixNGo|Management|remotedesktop|DR|RD connection broker
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10003_root001_4a6312899c2e4ba4bafef208b900240a|FixNGo|Management|remotedesktop|DR|RD connection broker
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10004_data001_7185e2c7a3a54a0d95f141e6e3da6dca|FixNGo|Management|remotedesktop|DR|RD licensing
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10004_data002_c9538e76f44646fb9ac9ef57be97911f|FixNGo|Management|remotedesktop|DR|RD licensing
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-MGMT-LIVE-DR/providers/Microsoft.Compute/disks/DRMRW10004_root001_305ec57025ff4981be230c3350d7c9a4|FixNGo|Management|remotedesktop|DR|RD licensing
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/disks/DRMRW10007_data001|FixNGo|Management|remotedesktop|DR|RD jump server 2 (General access 1)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/disks/DRMRW10007_data002|FixNGo|Management|remotedesktop|DR|RD jump server 2 (General access 1)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/NOMS-Mgmt-Live-DR/providers/Microsoft.Compute/disks/DRMRW10007_root001|FixNGo|Management|remotedesktop|DR|RD jump server 2 (General access 1)
@@ -1000,67 +1022,67 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-oasys/providers/Microsoft.Network/networkInterfaces/PDOWL00033-nic|OASys|OASys|ha|prod|OASys HA Proxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-oasys/providers/Microsoft.Network/networkInterfaces/PDOWL00035-nic|OASys|OASys|ha|prod|Training HA Proxy Node
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-oasys/providers/Microsoft.Network/networkInterfaces/PDOWL00036-nic|OASys|OASys|ha|prod|Practice HA Proxy Node
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPDLPNDB1-as|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPDLPNDB2-as|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPDLPNDB1-as|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPDLPNDB2-as|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPDWPNWFS-as|NOMIS|NOMIS|data|prod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPMLNDHAP-as|NOMIS|NDH|mid|prod|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPMLNDHEM-as|NOMIS|NDH|mid|prod|NDH EMS Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPMWNDHDS-as|NOMIS|NDH|mid|prod|NDH Windows Distribution Server
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPWLCNOMA-as|NOMIS|NOMIS|web|prod|C-NOMIS AppServer Weblogic
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PDPWLPNOMHA1-as|NOMIS|NOMIS|ha|prod|C-NOMIS HAProxy Node1
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/nomis-binary-fixed-disk|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK21|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK22|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK23|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK24|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK3|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-19|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-20|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-21|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-22|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-23|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-24|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035_data001|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035_data002|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK20|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK21|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK22|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK23|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK24|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-19|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-20|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-21|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-22|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-23|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-24|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036_data001|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036_data002|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036_root001|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-DISK20|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-DISK21|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-DISK22|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-10|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-11|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-12|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-8|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-9|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037_data001|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037_data002|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037_root001|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK20|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK21|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK22|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK23|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK24|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-15|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-16|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-17|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-18|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-19|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-20|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038_data001|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038_data002|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038_root001|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/nomis-binary-fixed-disk|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK21|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK22|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK23|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK24|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-DISK3|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-19|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-20|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-21|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-22|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-23|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035-NEWDISK-ASM-24|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035_data001|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00035_data002|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK20|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK21|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK22|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK23|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-DISK24|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-19|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-20|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-21|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-22|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-23|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036-NEWDISK-ASM-24|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036_data001|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036_data002|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00036_root001|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-DISK20|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-DISK21|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-DISK22|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-10|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-11|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-12|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-8|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037-NEWDISK-ASM-9|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037_data001|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037_data002|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00037_root001|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK20|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK21|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK22|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK23|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-DISK24|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-15|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-16|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-17|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-18|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-19|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038-NEWDISK-ASM-20|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038_data001|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038_data002|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00038_root001|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00062-DISK13|NOMIS|NOMIS|data|prod|C-NOMIS DB High-Availability/DataGuard
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00062-DISK14|NOMIS|NOMIS|data|prod|C-NOMIS DB High-Availability/DataGuard
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPDL00062-DISK15|NOMIS|NOMIS|data|prod|C-NOMIS DB High-Availability/DataGuard
@@ -1121,11 +1143,11 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPWL00052_data001|NOMIS|NOMIS|ha|prod|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPWL00052_data002|NOMIS|NOMIS|ha|prod|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PDPWL00052_root001|NOMIS|NOMIS|ha|prod|C-NOMIS HAProxy Node2
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-NEWDISK-12|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00035|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00036|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00037|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00038|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PD-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-NEWDISK-12|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00035|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00036|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00037|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00038|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDL00062|NOMIS|NOMIS|data|prod|C-NOMIS DB High-Availability/DataGuard
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPDW00057|NOMIS|NOMIS|data|prod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPML00025|NOMIS|NDH|mid|prod|NDH Admin Tibco Node1
@@ -1143,10 +1165,10 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPWL00051|NOMIS|NOMIS|ha|prod|C-NOMIS HAProxy Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Compute/virtualMachines/PDPWL00052|NOMIS|NOMIS|ha|prod|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/loadBalancers/PD-PrisonNOMIS-NOMIS-LB1-v2|NOMIS|NOMIS|web|prod|
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00035-nic|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00036-nic|NOMIS|MIS|data|prod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00037-nic|NOMIS|NDH|data|prod|NDH Oracle DB (NDHP,TRDATP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00038-nic|NOMIS|NOMIS|data|prod|Audit (CNMAUDP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00035-nic|NOMIS|NOMIS|data|prod|C-NOMIS Oracle DB (CNOM)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00036-nic|NOMIS|MIS|data|prod|MIS Oracle DB (MIS)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00037-nic|NOMIS|NDH|data|prod|NDH Oracle DB (NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00038-nic|NOMIS|NOMIS|data|prod|Audit (CNMAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDL00062-nic|NOMIS|NOMIS|data|prod|C-NOMIS DB High-Availability/DataGuard
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPDW00057-nic|NOMIS|NOMIS|data|prod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pd-prison-nomis/providers/Microsoft.Network/networkInterfaces/PDPML00025-nic|NOMIS|NDH|mid|prod|NDH Admin Tibco Node1
@@ -1452,26 +1474,26 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-oasys/providers/Microsoft.Network/networkInterfaces/PPOWL00031-nic|OASys|OASys|ha|preprod|OASys HA Proxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-oasys/providers/Microsoft.Network/networkInterfaces/PPOWL00032-nic|OASys|ONR|ha|preprod|ONR HA Proxy Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-oasys/providers/Microsoft.Network/networkInterfaces/PPOWL00033-nic|OASys|ONR|ha|preprod|ONR HA Proxy Node2
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PPPDLPNDB1-as|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PPPDLPNDB1-as|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PPPDWPNWFS-as|NOMIS|NOMIS|data|preprod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PPPMLNDHAP-as|NOMIS|NDH|mid|preprod|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PPPMLNDHEM-as|NOMIS|NDH|mid|preprod|NDH EMS Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PPPWLCNOMA-as|NOMIS|NOMIS|web|preprod|C-NOMIS AppServer Weblogic
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/availabilitySets/PPPWLPNOMHA1-as|NOMIS|NOMIS|ha|preprod|C-NOMIS HAProxy Node1
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-DISK21|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-NEWDISK-11|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-NEWDISK-13|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-PRISON-NOMIS/providers/Microsoft.Compute/disks/pppdl00016-newdisk-14|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016_data001|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016_data002|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016_root001|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017-NEWDISK-10|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017-NEWDISK-11|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017-NEWDISK-12|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/pppdl00017-newdisk-13|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017_data001|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017_data002|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017_root001|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-DISK21|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-NEWDISK-11|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016-NEWDISK-13|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-PRISON-NOMIS/providers/Microsoft.Compute/disks/pppdl00016-newdisk-14|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016_data001|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016_data002|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00016_root001|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017-NEWDISK-10|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017-NEWDISK-11|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017-NEWDISK-12|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/pppdl00017-newdisk-13|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017_data001|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017_data002|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDL00017_root001|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDW00029-DISK1|NOMIS|NOMIS|data|preprod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDW00029_data001|NOMIS|NOMIS|data|preprod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPDW00029_data002|NOMIS|NOMIS|data|preprod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
@@ -1497,8 +1519,8 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPWL00052_data001|NOMIS|NOMIS|ha|preprod|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPWL00052_data002|NOMIS|NOMIS|ha|preprod|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-Prison-NOMIS/providers/Microsoft.Compute/disks/PPPWL00052_root001|NOMIS|NOMIS|ha|preprod|C-NOMIS HAProxy Node2
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-PRISON-NOMIS/providers/Microsoft.Compute/virtualMachines/PPPDL00016|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Compute/virtualMachines/PPPDL00017|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/PP-PRISON-NOMIS/providers/Microsoft.Compute/virtualMachines/PPPDL00016|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Compute/virtualMachines/PPPDL00017|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Compute/virtualMachines/PPPDW00029|NOMIS|NOMIS|data|preprod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Compute/virtualMachines/PPPML00007|NOMIS|NDH|mid|preprod|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Compute/virtualMachines/PPPML00009|NOMIS|NDH|mid|preprod|NDH EMS Tibco Node1
@@ -1508,8 +1530,8 @@ id|tags.service|tags.application|tags.component|tags.environment_name|tags.descr
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Compute/virtualMachines/PPPWL00051|NOMIS|NOMIS|ha|preprod|C-NOMIS HAProxy Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Compute/virtualMachines/PPPWL00052|NOMIS|NOMIS|ha|preprod|C-NOMIS HAProxy Node2
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/loadBalancers/PP-PrisonNOMIS-NOMIS-LB1-v2|NOMIS|NOMIS|web|preprod|
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/networkInterfaces/PPPDL00016-nic|NOMIS|NOMIS|data|preprod|C-NOMIS Oracle DB (CNOMP,ORAUDP,ORSYSP)
-/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/networkInterfaces/PPPDL00017-nic|NOMIS|MIS|data|preprod|MIS Oracle DB (MISP,MISAUDP,MISSYSP)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/networkInterfaces/PPPDL00016-nic|NOMIS|NOMIS|data|preprod|C-NOMIS and NDH Oracle DB (CNOM,NDH,TRDAT)
+/subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/networkInterfaces/PPPDL00017-nic|NOMIS|MIS|data|preprod|MIS and Audit Oracle DB (MIS,CNMAUD)
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/networkInterfaces/PPPDW00029-nic|NOMIS|NOMIS|data|preprod|Windows File Share Server (BOE Data) - Offloc - Contingency Reports
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/networkInterfaces/PPPML00007-nic|NOMIS|NDH|mid|preprod|NDH Admin Tibco Node1
 /subscriptions/1d95dcda-65b2-4273-81df-eb979c6b547b/resourceGroups/pp-prison-nomis/providers/Microsoft.Network/networkInterfaces/PPPML00009-nic|NOMIS|NDH|mid|preprod|NDH EMS Tibco Node1


### PR DESCRIPTION
Fixing Nomis DB tags - the description now includes the databases running on each VM.
Plus other alignments with DSO sheet, e.g. removal of WMT.